### PR TITLE
Back sync globals

### DIFF
--- a/packages/blocks/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/blocks/src/components/Avatar/Avatar.stories.tsx
@@ -61,9 +61,14 @@ export const AvatarSkins = () => {
           variant: 'danger',
           icon: <CircleWarningIcon className="t-icon" />,
         },
+        {
+          variant: 'dark',
+          icon: <CircleWarningIcon className="t-icon" />,
+        },
       ].map((item) => (
         <Avatar icon={item.icon} variant={item.variant as VariantT} />
       ))}
     </div>
   );
 }
+

--- a/packages/blocks/src/components/Avatar/Avatar.tsx
+++ b/packages/blocks/src/components/Avatar/Avatar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 
 export type SizeT = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
-export type VariantT = 'primary' | 'success' | 'warning' | 'danger';
+export type VariantT = 'primary' | 'success' | 'warning' | 'danger' | 'dark' | 'default';
 
 type AvatarProps = {
   size?: SizeT;
@@ -17,7 +17,7 @@ export const Avatar: React.FC<
       React.HTMLAttributes<HTMLDivElement>,
       HTMLDivElement
     >
-> = ({ size, children, imageUrl, icon, variant, className, ...props }) => {
+> = ({ size, children, imageUrl, icon, variant = 'default', className, ...props }) => {
   return (
     <div
       {...props}

--- a/packages/blocks/src/components/RadioCard/RadioCard.tsx
+++ b/packages/blocks/src/components/RadioCard/RadioCard.tsx
@@ -19,7 +19,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
   return (
     <div
       className={cx('t-radio-card', {
-        't-tag-blue': isSelected,
+        't-radio-card-selected': isSelected,
         [className]: !!className
       })}
       onClick={() => {

--- a/packages/blocks/styles/components/t-avatar.css
+++ b/packages/blocks/styles/components/t-avatar.css
@@ -10,9 +10,7 @@
            w-8
            rounded-full
            font-medium
-           overflow-hidden
-           bg-gray-200
-           text-gray-500;
+           overflow-hidden;
 }
 
 .t-avatar-img {
@@ -54,8 +52,8 @@
 }
 
 .t-avatar-xl .t-icon {
-    @apply w-8
-           h-8;
+    @apply w-6
+           h-6;
 }
 
 .t-avatar-2xl {
@@ -68,6 +66,12 @@
 }
 
 /* Skins */
+.t-avatar-default {
+  @apply bg-gray-100
+         text-gray-450
+         mix-blend-multiply;
+}
+
 .t-avatar-primary {
     @apply bg-blue-600
            text-white;
@@ -102,3 +106,4 @@
     @apply bg-lime-200
            text-lime-600;
 }
+

--- a/packages/blocks/styles/components/t-button-toolbar.css
+++ b/packages/blocks/styles/components/t-button-toolbar.css
@@ -6,9 +6,6 @@
 
 .t-button-toolbar {
     @apply flex
-           items-center;
-}
-
-.t-button-toolbar .t-button + .t-button {
-    @apply ml-2;
+           items-center
+           space-x-3;
 }

--- a/packages/blocks/styles/components/t-modal.css
+++ b/packages/blocks/styles/components/t-modal.css
@@ -47,7 +47,7 @@
           shadow-xl
           transform
           transition-all
-          sm_align-middle
+          align-middle
           sm_max-w-2xl
           w-full;
 }

--- a/packages/blocks/styles/components/t-radio-card.css
+++ b/packages/blocks/styles/components/t-radio-card.css
@@ -19,8 +19,8 @@
          text-gray-600;
 }
 
-.t-radio-card.t-tag-blue {
-  @apply bg-blue-100
+.t-radio-card.t-radio-card-selected {
+  @apply bg-blue-50
          text-blue-600
          ring-1
          ring-inset


### PR DESCRIPTION
- Synced a few things back from [globals.css](https://github.com/mergestat/mergestat/blob/main/ui/src/styles/globals.css) to `blocks`
  - The `RadioCard` component used `t-tag-blue` for the active state, renamed to `t-radio-card-selected`
  -  Added `align-middle` instead of `sm_align-middle` class to `t-modal` (caused modals to not be centered on smaller screens)
  - Increased t-button-toolbar spacing 
  - Updated default avatar skin to a lighter gray, made icons slightly smaller on the xl variant and added a dark avatar variant

#### Avatar sizes:
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/36261498/206465118-2a865e39-8189-4c32-9935-75c073e2c2bb.png">

#### Avatar skins
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/36261498/206465224-8b76c840-fc49-4a54-babb-df8b9f44f626.png">
